### PR TITLE
Add basic musical note shooter in Godot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# codex-game-test-godot
+# Codex Music Game
+
+This repository contains a minimal Godot project demonstrating a top-down player
+that shoots musical notes. The player currently starts with a trumpet.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,12 @@
+[gd_resource type="ConfigFile" load_steps=2 format=2]
+
+[application]
+config/name="CodexMusicGame"
+config/icon=""
+
+[input]
+move_up={"deadzone":0.5,"events":[{"type":"InputEventKey","scancode":87}]}
+move_down={"deadzone":0.5,"events":[{"type":"InputEventKey","scancode":83}]}
+move_left={"deadzone":0.5,"events":[{"type":"InputEventKey","scancode":65}]}
+move_right={"deadzone":0.5,"events":[{"type":"InputEventKey","scancode":68}]}
+fire={"deadzone":0.5,"events":[{"type":"InputEventMouseButton","button_index":1,"pressed":true}]}

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scripts/player.gd" type="Script" id=1]
+
+[node name="Player" type="KinematicBody2D"]
+script = ExtResource(1)
+
+[node name="Sprite" type="Sprite" parent="."]
+

--- a/scenes/Projectile.tscn
+++ b/scenes/Projectile.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://scripts/projectile.gd" type="Script" id=1]
+
+[node name="Projectile" type="Area2D"]
+script = ExtResource(1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = CircleShape2D { radius = 4 }
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,0 +1,30 @@
+extends KinematicBody2D
+
+export var speed := 200
+var current_instrument := "trumpet"
+
+onready var projectile_scene := preload("res://scenes/Projectile.tscn")
+
+func _physics_process(delta):
+    var velocity := Vector2.ZERO
+    if Input.is_action_pressed("move_right"):
+        velocity.x += 1
+    if Input.is_action_pressed("move_left"):
+        velocity.x -= 1
+    if Input.is_action_pressed("move_down"):
+        velocity.y += 1
+    if Input.is_action_pressed("move_up"):
+        velocity.y -= 1
+    if velocity != Vector2.ZERO:
+        velocity = velocity.normalized() * speed
+    move_and_slide(velocity)
+    look_at(get_global_mouse_position())
+    if Input.is_action_just_pressed("fire"):
+        fire()
+
+func fire():
+    var projectile = projectile_scene.instance()
+    projectile.global_position = global_position
+    projectile.direction = (get_global_mouse_position() - global_position).normalized()
+    projectile.note_sound = load("res://sounds/trumpet_c_note.ogg")
+    get_parent().add_child(projectile)

--- a/scripts/projectile.gd
+++ b/scripts/projectile.gd
@@ -1,0 +1,18 @@
+extends Area2D
+
+export var speed := 600
+var direction := Vector2.ZERO
+var note_sound : AudioStream
+
+onready var audio_player := $AudioStreamPlayer2D
+
+func _ready():
+    audio_player.stream = note_sound
+    connect("body_entered", self, "_on_body_entered")
+
+func _physics_process(delta):
+    position += direction * speed * delta
+
+func _on_body_entered(body):
+    audio_player.play()
+    queue_free()


### PR DESCRIPTION
## Summary
- initialize minimal Godot project
- add player that moves with WASD, aims with mouse and fires projectiles
- add projectile scene that plays a trumpet C note on collision
- provide placeholder audio file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883eb26bc548323a9b00dd0b812518d